### PR TITLE
chore(actions): Replace deprecated ::set-output syntax on action

### DIFF
--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -22,7 +22,7 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
     - id: get-app-version
       name: Get archetype version
-      run: echo "::set-output name=APP_VERSION::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)"
+      run: echo "APP_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)" >> $GITHUB_OUTPUT
     - name: Build and test archetype
       run: ./mvnw -B -ntp clean package
     - name: Upload archetype for tests


### PR DESCRIPTION
On may, ::set-output name={name}::{value} will be EOL, we replaced it from echo "{name}={value}" >> $GITHUB_OUTPUT syntax