### PR TITLE
chore(build): Allow to keep node_modules

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -10,6 +10,31 @@
 	<name>${displayName}</name>
 	<description>${description}</description>
 
+	<profiles>
+		<profile>
+			<id>keepNodeModules</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-clean-plugin</artifactId>
+						<configuration>
+							<filesets>
+								<fileset>
+									<directory>node</directory>
+									<followSymlinks>false</followSymlinks>
+								</fileset>
+							</filesets>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<properties>
 		<node.version>v20.9.0</node.version>
 		<npm.version>10.8.1</npm.version>


### PR DESCRIPTION
node_modules is usefull if you want to go offline.
Make it optional in the maven clean so Code Deposit can keep it.